### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/lazy-trie.opam
+++ b/lazy-trie.opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>="4.03.0"}
   "sexplib"
   "ppx_sexp_conv"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-lazy-trie"
 doc: "https://mirage.github.io/ocaml-lazy-trie/"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.